### PR TITLE
Percent-decode Web URL fragments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ dunce = "1.0.0"
 kuchiki = "*"
 regex = "*"
 lazy_static = "*"
+percent-encoding = "2.1.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/validation/web.rs
+++ b/src/validation/web.rs
@@ -2,6 +2,7 @@ use crate::validation::{CacheEntry, Context, Reason};
 use http::HeaderMap;
 use kuchiki::parse_html;
 use kuchiki::traits::TendrilSink;
+use percent_encoding::percent_decode;
 use reqwest::{Client, Response, Url};
 use std::time::SystemTime;
 
@@ -48,6 +49,7 @@ where
     }
 
     let result = if let Some(fragment) = url.fragment() {
+        let fragment = percent_decode(fragment.as_bytes()).decode_utf8_lossy();
         log::debug!("Checking \"{}\" contains \"{}\"", url, fragment);
         let response =
             get(ctx.client(), url.clone(), ctx.url_specific_headers(&url))


### PR DESCRIPTION
The URL fragment check fails to detect valid fragments containing non-ASCII characters because some library in the toolchain is encoding them.

Probably not an issue for the Anki manual, but we're currently using this fork in the [mdBook port of the AnkiDroid docs and its translations](https://github.com/ankidroid/ankidroiddocs/pull/101).